### PR TITLE
Picker in ScrollView

### DIFF
--- a/src/com/larswerkman/colorpicker/ColorPicker.java
+++ b/src/com/larswerkman/colorpicker/ColorPicker.java
@@ -690,6 +690,7 @@ public class ColorPicker extends View {
 			invalidate();
 			break;
 		}
+		getParent().requestDisallowInterceptTouchEvent(true);
 		return true;
 	}
 


### PR DESCRIPTION
Using the HoloColorPicker in a ScrollView or a ViewPager was impossible.
using requestDisallowInterceptTouchEvent(true) if the onTouch method
returns true is the way to get the ColorPicker working again
