### PR TITLE
Change color immediately when tapping anywhere on the color wheel

### DIFF
--- a/src/com/larswerkman/colorpicker/ColorPicker.java
+++ b/src/com/larswerkman/colorpicker/ColorPicker.java
@@ -555,8 +555,8 @@ public class ColorPicker extends View {
 
 				// Check whether user pressed on the color wheel
 				float radius = (float)Math.sqrt(x*x + y*y);
-				float minColorWheelPickingRadius = mColorWheelRadius - .5f * mColorPointerHaloRadius;
-				float maxColorWheelPickingRadius = mColorWheelRadius + .5f * mColorPointerHaloRadius;
+				float minColorWheelPickingRadius = mColorWheelRadius - mColorPointerHaloRadius;
+				float maxColorWheelPickingRadius = mColorWheelRadius + mColorPointerHaloRadius;
 
 				if(radius >= minColorWheelPickingRadius && radius <= maxColorWheelPickingRadius) {
 					mAngle = (float)Math.atan2(y, x);


### PR DESCRIPTION
When tapping anywhere on the color wheel, change the color immediately to the corresponding value. This eliminates the need for the user to first grab the pointer, and then drag it to the desired position. Not only is this a better fit to my personal preference, it is also consistent with the behavior of regular SeekBars. Note that this only changes the initial response, otherwise dragging behavior remains unchanged.
