### PR TITLE
set new color when restore instance state

### DIFF
--- a/src/com/larswerkman/colorpicker/ColorPicker.java
+++ b/src/com/larswerkman/colorpicker/ColorPicker.java
@@ -737,6 +737,8 @@ public class ColorPicker extends View {
 
 		mAngle = savedState.getFloat(STATE_ANGLE);
 		setOldCenterColor(savedState.getInt(STATE_OLD_COLOR));
-		mPointerColor.setColor(calculateColor(mAngle));
+		int currentColor = calculateColor(mAngle);
+		mPointerColor.setColor(currentColor);
+		setNewCenterColor(currentColor);
 	}
 }


### PR DESCRIPTION
Fiddling with cketti's HoloColorPicker-Demo I found that the SimpleColorPicker without any addtional bars does not keep the new color when restoring an instance. 
