### PR TITLE
Fire onColorChanged(...) event only once

### DIFF
--- a/src/com/larswerkman/holocolorpicker/ColorPicker.java
+++ b/src/com/larswerkman/holocolorpicker/ColorPicker.java
@@ -219,6 +219,11 @@ public class ColorPicker extends View {
 	 */
 	private OnColorChangedListener onColorChangedListener;
 
+	/**
+	 * {@code onColorSelectedListener} instance of the onColorSelectedListener
+	 */
+	private OnColorSelectedListener onColorSelectedListener;
+
 	public ColorPicker(Context context) {
 		super(context);
 		init(null, 0);
@@ -246,6 +251,15 @@ public class ColorPicker extends View {
 	}
 
 	/**
+	 * An interface that is called whenever a new color has been selected.
+	 * Currently it is always called when the color wheel has been released.
+	 * 
+	 */
+	public interface OnColorSelectedListener {
+		public void onColorSelected(int color);
+	}
+
+	/**
 	 * Set a onColorChangedListener
 	 * 
 	 * @param {@code OnColorChangedListener}
@@ -262,12 +276,34 @@ public class ColorPicker extends View {
 	public OnColorChangedListener getOnColorChangedListener() {
 		return this.onColorChangedListener;
 	}
-	
+
+	/**
+	 * Set a onColorSelectedListener
+	 * 
+	 * @param {@code OnColorSelectedListener}
+	 */
+	public void setOnColorSelectedListener(OnColorSelectedListener listener) {
+		this.onColorSelectedListener = listener;
+	}
+
+	/**
+	 * Gets the onColorSelectedListener
+	 * 
+	 * @return {@code OnColorSelectedListener}
+	 */
+	public OnColorSelectedListener getOnColorSelectedListener() {
+		return this.onColorSelectedListener;
+	}	
 	
 	/**
-	 * Color of the latest entry of the listener.
+	 * Color of the latest entry of the onColorChangedListener.
 	 */
-	private int oldListenerColor;
+	private int oldChangedListenerColor;
+	
+	/**
+	 * Color of the latest entry of the onColorSelectedListener.
+	 */
+	private int oldSelectedListenerColor;
 
 	private void init(AttributeSet attrs, int defStyle) {
 		final TypedArray a = getContext().obtainStyledAttributes(attrs,
@@ -602,9 +638,31 @@ public class ColorPicker extends View {
 			}
 			break;
 		case MotionEvent.ACTION_UP:
+		case MotionEvent.ACTION_CANCEL:
 			mUserIsMovingPointer = false;
 			mCenterHaloPaint.setAlpha(0x00);
+<<<<<<< HEAD
+			
+			if (onColorChangedListener != null && mCenterNewColor != oldListenerColor) {
+				onColorChangedListener.onColorChanged(mCenterNewColor);
+				oldListenerColor = mCenterNewColor;
+			}
+			
+=======
+
+			if (onColorSelectedListener != null && mCenterNewColor != oldSelectedListenerColor) {
+				onColorSelectedListener.onColorSelected(mCenterNewColor);
+				oldSelectedListenerColor = mCenterNewColor;
+			}
+
+>>>>>>> Added onColorSelectedListener
 			invalidate();
+			break;
+		case MotionEvent.ACTION_CANCEL:
+			if (onColorSelectedListener != null && mCenterNewColor != oldSelectedListenerColor) {
+				onColorSelectedListener.onColorSelected(mCenterNewColor);
+				oldSelectedListenerColor = mCenterNewColor;
+			}
 			break;
 		}
 		return true;
@@ -678,10 +736,13 @@ public class ColorPicker extends View {
 			mCenterOldColor = color;
 			mCenterOldPaint.setColor(color);
 		}
-		if (onColorChangedListener != null && color != oldListenerColor) {
+<<<<<<< HEAD
+=======
+		if (onColorChangedListener != null && color != oldChangedListenerColor) {
 			onColorChangedListener.onColorChanged(color);
-			oldListenerColor = color;
+			oldChangedListenerColor = color;
 		}
+>>>>>>> Added onColorSelectedListener
 		invalidate();
 	}
 


### PR DESCRIPTION
Before this change, the onColorChanged(...) event was fired hundreds of times while moving the color wheel. Now it is fired only once after the user released the color wheel again.
