### PR TITLE
Add onOpacityChangedListener

### DIFF
--- a/src/com/larswerkman/holocolorpicker/OpacityBar.java
+++ b/src/com/larswerkman/holocolorpicker/OpacityBar.java
@@ -139,7 +139,7 @@ public class OpacityBar extends View {
     private OnOpacityChangedListener onOpacityChangedListener;
 
     public interface OnOpacityChangedListener {
-        public void onOpacityChanged(int color);
+        public void onOpacityChanged(int opacity);
     }
 
     public void setOnOpacityChangedListener(OnOpacityChangedListener listener) {


### PR DESCRIPTION
Added the ability to use onOpacityChangedListener to detect when the opacity slider widget has been moved in situations when the OpacityBar widget is used standalone (i.e. without the color picker).
