### PR TITLE
add setOldCenterColor() in setColor()

### DIFF
--- a/src/com/larswerkman/holocolorpicker/ColorPicker.java
+++ b/src/com/larswerkman/holocolorpicker/ColorPicker.java
@@ -566,6 +566,7 @@ public class ColorPicker extends View {
 			mValueBar.setValue(mHSV[2]);
 		}
         setNewCenterColor(color);
+        setOldCenterColor(color);
 	}
 
 	/**


### PR DESCRIPTION
Hey, I want to thank you for your great work and clean code in the first place. HoloColorPicker is just wonderful.
And I believe I just find a bug .It's about the old and new color in the center. I think once a new color is picked, after a MotionEvent.ACTION_MOVE case is called, both old and new center color should be set to the picked color. With both old and new combined into one solid round, the HoloColorPicker can represent the new picked color in a better way. 
In additon, if I want to initialize the initial color of HoloColorPicker with another color, instead of the one hard-coded in HoloColorPicker, the new setColor() will just satisfy me.
Correct me if anything wrong. Look forward to your reply. Thank you for your nice job again.
