### PR TITLE
Made color changes trigger for a tap, not just a drag

### DIFF
--- a/libary/src/main/java/com/larswerkman/holocolorpicker/ColorPicker.java
+++ b/libary/src/main/java/com/larswerkman/holocolorpicker/ColorPicker.java
@@ -615,6 +615,21 @@ public class ColorPicker extends View {
                                         && Math.sqrt(x*x + y*y) >= mColorWheelRadius - mColorPointerHaloRadius
                                         && mTouchAnywhereOnColorWheelEnabled) {
                                 mUserIsMovingPointer = true;
+				mAngle = (float) Math.atan2(y - mSlopY, x - mSlopX);
+				setNewCenterColor(mCenterNewColor = calculateColor(mAngle));
+				mPointerColor.setColor(calculateColor(mAngle));
+				if (mOpacityBar != null) {
+					mOpacityBar.setColor(mColor);
+				}
+				if (mValueBar != null) {
+					mValueBar.setColor(mColor);
+				}
+				if (mSaturationBar != null) {
+					mSaturationBar.setColor(mColor);
+				}
+				if (mSVbar != null) {
+					mSVbar.setColor(mColor);
+				}
                                 invalidate();
                         }
 			// If user did not press pointer or center, report event not handled

--- a/libary/src/main/java/com/larswerkman/holocolorpicker/OpacityBar.java
+++ b/libary/src/main/java/com/larswerkman/holocolorpicker/OpacityBar.java
@@ -357,6 +357,9 @@ public class OpacityBar extends View {
 				mBarPointerPosition = Math.round(dimen);
 				calculateColor(Math.round(dimen));
 				mBarPointerPaint.setColor(mColor);
+                                if (mPicker != null) {
+                                        mPicker.setNewCenterColor(mColor);
+                                }
 				invalidate();
 			}
 			break;
@@ -367,28 +370,18 @@ public class OpacityBar extends View {
 						&& dimen <= (mBarPointerHaloRadius + mBarLength)) {
 					mBarPointerPosition = Math.round(dimen);
 					calculateColor(Math.round(dimen));
-					mBarPointerPaint.setColor(mColor);
-					if (mPicker != null) {
-						mPicker.setNewCenterColor(mColor);
-					}
-					invalidate();
 				} else if (dimen < mBarPointerHaloRadius) {
 					mBarPointerPosition = mBarPointerHaloRadius;
 					mColor = Color.TRANSPARENT;
-					mBarPointerPaint.setColor(mColor);
-					if (mPicker != null) {
-						mPicker.setNewCenterColor(mColor);
-					}
-					invalidate();
 				} else if (dimen > (mBarPointerHaloRadius + mBarLength)) {
 					mBarPointerPosition = mBarPointerHaloRadius + mBarLength;
 					mColor = Color.HSVToColor(mHSVColor);
-					mBarPointerPaint.setColor(mColor);
-					if (mPicker != null) {
-						mPicker.setNewCenterColor(mColor);
-					}
-					invalidate();
 				}
+                                mBarPointerPaint.setColor(mColor);
+                                if (mPicker != null) {
+                                        mPicker.setNewCenterColor(mColor);
+                                }
+                                invalidate();
 			}
 			if(onOpacityChangedListener != null && oldChangedListenerOpacity != getOpacity()){
 	            onOpacityChangedListener.onOpacityChanged(getOpacity());

--- a/libary/src/main/java/com/larswerkman/holocolorpicker/SVBar.java
+++ b/libary/src/main/java/com/larswerkman/holocolorpicker/SVBar.java
@@ -338,6 +338,10 @@ public class SVBar extends View {
 				mBarPointerPosition = Math.round(dimen);
 				calculateColor(Math.round(dimen));
 				mBarPointerPaint.setColor(mColor);
+                                if (mPicker != null) {
+                                        mPicker.setNewCenterColor(mColor);
+                                        mPicker.changeOpacityBarColor(mColor);
+                                }
 				invalidate();
 			}
 			break;
@@ -348,31 +352,19 @@ public class SVBar extends View {
 						&& dimen <= (mBarPointerHaloRadius + mBarLength)) {
 					mBarPointerPosition = Math.round(dimen);
 					calculateColor(Math.round(dimen));
-					mBarPointerPaint.setColor(mColor);
-					if (mPicker != null) {
-						mPicker.setNewCenterColor(mColor);
-						mPicker.changeOpacityBarColor(mColor);
-					}
-					invalidate();
 				} else if (dimen < mBarPointerHaloRadius) {
 					mBarPointerPosition = mBarPointerHaloRadius;
 					mColor = Color.WHITE;
-					mBarPointerPaint.setColor(mColor);
-					if (mPicker != null) {
-						mPicker.setNewCenterColor(mColor);
-						mPicker.changeOpacityBarColor(mColor);
-					}
-					invalidate();
 				} else if (dimen > (mBarPointerHaloRadius + mBarLength)) {
 					mBarPointerPosition = mBarPointerHaloRadius + mBarLength;
 					mColor = Color.BLACK;
-					mBarPointerPaint.setColor(mColor);
-					if (mPicker != null) {
-						mPicker.setNewCenterColor(mColor);
-						mPicker.changeOpacityBarColor(mColor);
-					}
-					invalidate();
 				}
+                                mBarPointerPaint.setColor(mColor);
+                                if (mPicker != null) {
+                                        mPicker.setNewCenterColor(mColor);
+                                        mPicker.changeOpacityBarColor(mColor);
+                                }
+                                invalidate();
 			}
 			break;
 		case MotionEvent.ACTION_UP:

--- a/libary/src/main/java/com/larswerkman/holocolorpicker/SaturationBar.java
+++ b/libary/src/main/java/com/larswerkman/holocolorpicker/SaturationBar.java
@@ -357,6 +357,11 @@ public class SaturationBar extends View {
 				mBarPointerPosition = Math.round(dimen);
 				calculateColor(Math.round(dimen));
 				mBarPointerPaint.setColor(mColor);
+                                if (mPicker != null) {
+                                        mPicker.setNewCenterColor(mColor);
+                                        mPicker.changeValueBarColor(mColor);
+                                        mPicker.changeOpacityBarColor(mColor);
+                                }
 				invalidate();
 			}
 			break;
@@ -367,34 +372,20 @@ public class SaturationBar extends View {
 						&& dimen <= (mBarPointerHaloRadius + mBarLength)) {
 					mBarPointerPosition = Math.round(dimen);
 					calculateColor(Math.round(dimen));
-					mBarPointerPaint.setColor(mColor);
-					if (mPicker != null) {
-						mPicker.setNewCenterColor(mColor);
-						mPicker.changeValueBarColor(mColor);
-						mPicker.changeOpacityBarColor(mColor);
-					}
-					invalidate();
 				} else if (dimen < mBarPointerHaloRadius) {
 					mBarPointerPosition = mBarPointerHaloRadius;
 					mColor = Color.WHITE;
-					mBarPointerPaint.setColor(mColor);
-					if (mPicker != null) {
-						mPicker.setNewCenterColor(mColor);
-						mPicker.changeValueBarColor(mColor);
-						mPicker.changeOpacityBarColor(mColor);
-					}
-					invalidate();
 				} else if (dimen > (mBarPointerHaloRadius + mBarLength)) {
 					mBarPointerPosition = mBarPointerHaloRadius + mBarLength;
 					mColor = Color.HSVToColor(mHSVColor);
-					mBarPointerPaint.setColor(mColor);
-					if (mPicker != null) {
-						mPicker.setNewCenterColor(mColor);
-						mPicker.changeValueBarColor(mColor);
-						mPicker.changeOpacityBarColor(mColor);
-					}
-					invalidate();
 				}
+                                mBarPointerPaint.setColor(mColor);
+                                if (mPicker != null) {
+                                        mPicker.setNewCenterColor(mColor);
+                                        mPicker.changeValueBarColor(mColor);
+                                        mPicker.changeOpacityBarColor(mColor);
+                                }
+                                invalidate();
 			}
 			if(onSaturationChangedListener != null && oldChangedListenerSaturation != mColor){
 	            onSaturationChangedListener.onSaturationChanged(mColor);

--- a/libary/src/main/java/com/larswerkman/holocolorpicker/ValueBar.java
+++ b/libary/src/main/java/com/larswerkman/holocolorpicker/ValueBar.java
@@ -358,6 +358,10 @@ public class ValueBar extends View {
 				mBarPointerPosition = Math.round(dimen);
 				calculateColor(Math.round(dimen));
 				mBarPointerPaint.setColor(mColor);
+                                if (mPicker != null) {
+                                        mPicker.setNewCenterColor(mColor);
+                                        mPicker.changeOpacityBarColor(mColor);
+                                }
 				invalidate();
 			}
 			break;
@@ -368,31 +372,19 @@ public class ValueBar extends View {
 						&& dimen <= (mBarPointerHaloRadius + mBarLength)) {
 					mBarPointerPosition = Math.round(dimen);
 					calculateColor(Math.round(dimen));
-					mBarPointerPaint.setColor(mColor);
-					if (mPicker != null) {
-						mPicker.setNewCenterColor(mColor);
-						mPicker.changeOpacityBarColor(mColor);
-					}
-					invalidate();
 				} else if (dimen < mBarPointerHaloRadius) {
 					mBarPointerPosition = mBarPointerHaloRadius;
 					mColor = Color.HSVToColor(mHSVColor);
-					mBarPointerPaint.setColor(mColor);
-					if (mPicker != null) {
-						mPicker.setNewCenterColor(mColor);
-						mPicker.changeOpacityBarColor(mColor);
-					}
-					invalidate();
 				} else if (dimen > (mBarPointerHaloRadius + mBarLength)) {
 					mBarPointerPosition = mBarPointerHaloRadius + mBarLength;
 					mColor = Color.BLACK;
-					mBarPointerPaint.setColor(mColor);
-					if (mPicker != null) {
-						mPicker.setNewCenterColor(mColor);
-						mPicker.changeOpacityBarColor(mColor);
-					}
-					invalidate();
 				}
+                                mBarPointerPaint.setColor(mColor);
+                                if (mPicker != null) {
+                                        mPicker.setNewCenterColor(mColor);
+                                        mPicker.changeOpacityBarColor(mColor);
+                                }
+                                invalidate();
 			}
 			if(onValueChangedListener != null && oldChangedListenerValue != mColor){
 	            onValueChangedListener.onValueChanged(mColor);


### PR DESCRIPTION
In previous versions the colors would not change for a tap, only for drags.
Yet, on the bars, the pointer would move to the tapped position, suggesting
this wasn't the intended behavior. This commit addresses this problem.

This pull request solves https://github.com/LarsWerkman/HoloColorPicker/issues/66 (Issue 66)

Changes:
  The bars run the same code for taps as they do for drags.
  The color picker itself now responds to taps, to ensure a consistent experience.
  Minor refactoring by pulling repeated code out of if-else chains to outside the chain.
