### PR TITLE
Fix for colorToAngle method

### DIFF
--- a/libary/src/main/java/com/larswerkman/holocolorpicker/ColorPicker.java
+++ b/libary/src/main/java/com/larswerkman/holocolorpicker/ColorPicker.java
@@ -577,8 +577,10 @@ public class ColorPicker extends View {
 	private float colorToAngle(int color) {
 		float[] colors = new float[3];
 		Color.colorToHSV(color, colors);
-		
-		return (float) Math.toRadians(-colors[0]);
+
+		float rad = (float) Math.toRadians(colors[0]);
+		if (rad > Math.PI) rad -= 2 * Math.PI;
+		return rad;
 	}
 
 	@Override


### PR DESCRIPTION
The angle on the colorWheel uses a range from -PI to PI, while Math.toRadians gives back a range from 0 to 2_PI. I fixed this by subtracting 2_PI when the radians are above PI.
