### PR TITLE
Migrate to GradleMavenPush https://github.com/Vorlonsoft/GradleMavenPush

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,9 @@ GROUP=com.larswerkman
 
 POM_DESCRIPTION=A Holo themed colorpicker designed by marie schweiz
 POM_URL=https://github.com/LarsWerkman/HoloColorPicker
-POM_SCM_URL=https://github.com/chrisbanes/ActionBar-PullToRefresh
-POM_SCM_CONNECTION=scm:git:git://github.com/LarsWerkman/HoloColorPicker.git
-POM_SCM_DEV_CONNECTION=scm:git:git@github.com:LarsWerkman/HoloColorPicker.git
+POM_SCM_CONNECTION=scm:git@github.com:LarsWerkman/HoloColorPicker.git
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
-POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=larswerkman
 POM_DEVELOPER_NAME=Lars Werkman
+POM_DEVELOPER_EMAIL=werkman.lars@gmail.com

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,4 +9,4 @@ android {
     }
 }
 
-apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+apply from: 'https://raw.github.com/Vorlonsoft/GradleMavenPush/master/maven-push.gradle'

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -1,3 +1,2 @@
 POM_NAME=HoloColorPicker Library
 POM_ARTIFACT_ID=HoloColorPicker
-POM_PACKAGING=aar


### PR DESCRIPTION
Migrate to GradleMavenPush https://github.com/Vorlonsoft/GradleMavenPush

Reasons: 
- Old plugin don't have updates for 4 years
- Better javadocs generation
- Better pom file generation
- Smaller gradle.properties
- You can easy migrate from Maven Central to JCenter by adding to your code `IS_JCENTER = true` only and register at https://bintray.com/bintray/jcenter